### PR TITLE
Fix bug in argument script and simplify

### DIFF
--- a/Pod/Assets/Scripts/bootstrap.sh
+++ b/Pod/Assets/Scripts/bootstrap.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-
 if [ "$#" -eq 0 ] ; then
     ENABLE_LINES=1
     ENABLE_TODO=1
@@ -12,42 +11,34 @@ else
     ENABLE_PERUSER=0
     ENABLE_BUILDNBR=0
     ENABLE_ICONVERSIONING=0
+
+    for key in "$@"
+    do
+    	case $key in
+		-l)
+		    ENABLE_LINES=1
+		    ;;
+		-t)
+		    ENABLE_TODO=1
+		    ;;
+		-u)
+		    ENABLE_PERUSER=1
+		    ;;
+		-n)
+		    ENABLE_BUILDNBR=1
+		    ;;
+		-i)
+		    ENABLE_ICONVERSIONING=1
+		    ENABLE_BUILDNBR=1
+		    ;;
+		*)
+	            # unknown option
+		    echo Error: Unknown option $key 1>&2
+		    exit 1
+		    ;;
+	    esac
+    done
 fi
-
-while [[ $# > 0 ]]
-do
-    key="$1"
-
-    case $key in
-	-l)
-	    ENABLE_LINES=1
-	    shift
-	    ;;
-	-t)
-	    ENABLE_TODO=1
-	    shift
-	    ;;
-	-u)
-	    ENABLE_PERUSER=1
-	    shift
-	    ;;
-	-n)
-	    ENABLE_BUILDNBR=1
-	    shift
-	    ;;
-	-i)
-	    ENABLE_ICONVERSIONING=1
-	    ENABLE_BUILDNBR=1
-	    shift
-	    ;;
-	*)
-            # unknown option
-	    echo Error: Unknown option $key 1>&2
-	    exit 1
-	    ;;
-    esac
-    shift
-done
 
 DIR="${BASH_SOURCE%/*}"
 if [[ ! -d "${DIR}" ]]; then DIR="${PWD}"; fi
@@ -65,11 +56,12 @@ if [ "$ENABLE_LINES" -eq 1 ] ; then
 fi
 
 if [ "$ENABLE_TODO" -eq 1 ] ; then
-"${DIR}/todo.sh"
+	"${DIR}/todo.sh"
 fi
 if [ "$ENABLE_PERUSER" -eq 1 ] ; then
     "${DIR}/user.sh"
 fi
+
 
 bundled_plist=$(find "${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/" -name "KZBEnvironments.plist" | tr -d '\r')
 bundled_settings=$(find "${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/" -name "Settings.bundle" | tr -d '\r')


### PR DESCRIPTION
There's currently a bug in passing arguments for optional build settings with the extra shift at the end of the while loop that will skip every other parameter. This fixes that bug and simplifies the loop. 