### PR TITLE
Allow specifying the name of the production env

### DIFF
--- a/Pod/Assets/Scripts/bootstrap.sh
+++ b/Pod/Assets/Scripts/bootstrap.sh
@@ -68,7 +68,7 @@ bundled_settings=$(find "${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLD
 src_plist=$(find "${SRCROOT}" -name "KZBEnvironments.plist" | tr -d '\r')
 
 if [[ "${CONFIGURATION}" == *Release*  ]]; then
-  env -i xcrun -sdk macosx swift "${DIR}/processEnvironments.swift" "${bundled_plist}" "${src_plist}" "${bundled_settings}" "PRODUCTION"
+  env -i xcrun -sdk macosx swift "${DIR}/processEnvironments.swift" "${bundled_plist}" "${src_plist}" "${bundled_settings}" "${KZBEnv}"
 else
   env -i xcrun -sdk macosx swift "${DIR}/processEnvironments.swift" "${bundled_plist}" "${src_plist}" "${bundled_settings}"
 fi


### PR DESCRIPTION
Change bootstrap.sh to filter to the value of KZBEnv rather than the
hardcoded PRODUCTION. This allows the user to set the name of the
environment.

I needed this to be able to build a release build that was pointed at
our UAT environment for pen testing. I wanted to have the environments
filtered to UAT just as they would with a production build.