### PR TITLE
Update CocoaLumberjack version

### DIFF
--- a/KZBootstrap.podspec
+++ b/KZBootstrap.podspec
@@ -44,7 +44,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'Logging' do |ss|
     ss.source_files = 'Pod/Classes/Logging'
-    ss.dependency "CocoaLumberjack", "2.0.0-beta4"
+    ss.dependency "CocoaLumberjack", "~> 2.3.0"
   end
 
 end


### PR DESCRIPTION
An exact 2.0 beta version was required. Using ~> won't require this to be updated as frequently.